### PR TITLE
Support Zig 0.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.13.0
+          version: 0.14.0
       - run: zig build test --summary all
   lint:
     runs-on: ubuntu-latest
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.13.0
+          version: 0.14.0
       - run: zig fmt --check .
   test_build:
     strategy:
@@ -31,5 +31,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.13.0
+          version: 0.14.0
       - run: cd test-build && zig build --summary all

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,21 +1,15 @@
 .{
-    // This is the default name used by packages depending on this one. For
-    // example, when a user runs `zig fetch --save <url>`, this field is used
-    // as the key in the `dependencies` table. Although the user can choose a
-    // different name, most users will stick with this provided value.
-    //
-    // It is redundant to include "zig" in this name because it is already
-    // within the Zig package namespace.
-    .name = "base58",
+    .fingerprint = 0xed092d9e9b99e0eb,
+    .name = .base58,
 
     // This is a [Semantic Version](https://semver.org/).
     // In a future version of Zig it will be used for package deduplication.
-    .version = "0.13.3",
+    .version = "0.14.0",
 
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    .minimum_zig_version = "0.12.0",
+    .minimum_zig_version = "0.14.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.
@@ -24,8 +18,8 @@
     // internet connectivity.
     .dependencies = .{
         .clap = .{
-            .url = "https://github.com/Hejsil/zig-clap/archive/refs/tags/0.9.1.tar.gz",
-            .hash = "122062d301a203d003547b414237229b09a7980095061697349f8bef41be9c30266b",
+            .url = "https://github.com/Hejsil/zig-clap/archive/refs/tags/0.10.0.tar.gz",
+            .hash = "clap-0.10.0-oBajB434AQBDh-Ei3YtoKIRxZacVPF1iSwp3IX_ZB8f0",
         },
     },
     .paths = .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -58,7 +58,7 @@ pub fn generateKeypair(path: []const u8, allocator: std.mem.Allocator) !void {
             return err;
         }
 
-        const keypair = try std.crypto.sign.Ed25519.KeyPair.create(null);
+        const keypair = std.crypto.sign.Ed25519.KeyPair.generate();
         var keypair_json = std.ArrayList(u8).init(allocator);
         defer keypair_json.deinit();
         try std.json.stringify(keypair.secret_key.bytes, .{}, keypair_json.writer());

--- a/test-build/build.zig
+++ b/test-build/build.zig
@@ -5,7 +5,7 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
     const program = b.addSharedLibrary(.{
-        .name = "test-build",
+        .name = "test_build",
         .root_source_file = b.path("src/main.zig"),
         .optimize = optimize,
         .target = target,

--- a/test-build/build.zig.zon
+++ b/test-build/build.zig.zon
@@ -1,34 +1,15 @@
 .{
-    // This is the default name used by packages depending on this one. For
-    // example, when a user runs `zig fetch --save <url>`, this field is used
-    // as the key in the `dependencies` table. Although the user can choose a
-    // different name, most users will stick with this provided value.
-    //
-    // It is redundant to include "zig" in this name because it is already
-    // within the Zig package namespace.
-    .name = "base58-build-test",
-
-    // This is a [Semantic Version](https://semver.org/).
-    // In a future version of Zig it will be used for package deduplication.
+    .fingerprint = 0x39fc374771b60f58,
+    .name = .base58_build_test,
     .version = "0.13.0",
-
-    // This field is optional.
-    // This is currently advisory only; Zig does not yet do anything
-    // with this value.
-    .minimum_zig_version = "0.12.0",
-
-    // This field is optional.
-    // Each dependency must either provide a `url` and `hash`, or a `path`.
-    // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
-    // Once all dependencies are fetched, `zig build` no longer requires
-    // internet connectivity.
+    .minimum_zig_version = "0.14.0",
     .dependencies = .{
         .base58 = .{
             .path = "..",
         },
         .clap = .{
-            .url = "https://github.com/Hejsil/zig-clap/archive/refs/tags/0.9.1.tar.gz",
-            .hash = "122062d301a203d003547b414237229b09a7980095061697349f8bef41be9c30266b",
+            .url = "https://github.com/Hejsil/zig-clap/archive/refs/tags/0.10.0.tar.gz",
+            .hash = "clap-0.10.0-oBajB434AQBDh-Ei3YtoKIRxZacVPF1iSwp3IX_ZB8f0",
         },
     },
     .paths = .{


### PR DESCRIPTION
#### Problem

Zig 0.14 is out, but this package doesn't support it.

#### Summary of changes

Not too much to do:

* update the package name to be a valid Zig identifier
* add a fingerprint
* update the clap dep to 0.10
* use the new crypto functions